### PR TITLE
feat: implement vim-like editing mode with command parsing and mode h…

### DIFF
--- a/readme
+++ b/readme
@@ -1,0 +1,114 @@
+# Amoxcalli
+
+A terminal-based text editor written in Rust, inspired by Vim.
+
+**Amoxcalli** (from Nahuatl: *āmoxtli* "book" + *calli* "house") means "house of books" or "library" in the Aztec language. In pre-Columbian Mexico, the amoxcalli was the place where codices were stored and knowledge was preserved. This editor carries that spirit — a simple tool for writing and preserving text.
+
+## About
+
+This is a personal project built to learn Rust while creating something useful. It's a clone-style editor flavored by my own needs and preferences, implementing vim-like modal editing with a focus on simplicity and learning.
+
+## Features
+
+- **Modal Editing** — Normal and Insert modes, just like Vim
+- **Vim-style Commands** — `:w`, `:q`, `:wq`, `:q!`, and more
+- **Unicode Support** — Proper handling of multi-width and special characters
+- **Minimal Dependencies** — Only what's necessary
+- **Cross-platform** — Works on Linux, macOS, and Windows
+
+### Roadmap
+
+- [x] Vim controls style
+- [ ] File explorer built in
+- [ ] Code syntax highlighting
+- [ ] Themes
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/AbrhamSayd/amoxcalli-editor.git
+cd amoxcalli-editor
+
+# Build release version
+cargo build --release
+
+# The binary will be at ./target/release/amoxcalli
+```
+
+## Usage
+
+```bash
+# Open a new empty document
+./target/release/amoxcalli
+
+# Open an existing file
+./target/release/amoxcalli path/to/file.txt
+```
+
+### Keybindings
+
+| Key | Mode | Action |
+|-----|------|--------|
+| `i` | Normal | Enter Insert mode |
+| `I` | Normal | Enter Insert mode at line start |
+| `Esc` | Insert | Return to Normal mode |
+| `Arrow keys` | Any | Navigate |
+| `Home` / `End` | Any | Jump to line start/end |
+| `Page Up` / `Page Down` | Any | Scroll viewport |
+| `Backspace` | Insert | Delete character before cursor |
+| `Delete` | Insert | Delete character at cursor |
+
+### Commands
+
+Press `:` in Normal mode to enter command mode:
+
+| Command | Action |
+|---------|--------|
+| `:w` | Save file |
+| `:w <filename>` | Save as |
+| `:q` | Quit (fails if unsaved changes) |
+| `:q!` | Force quit without saving |
+| `:wq` or `:x` | Save and quit |
+| `:help` | Show help |
+
+## Project Structure
+
+```
+src/
+├── main.rs              # Entry point
+└── editor/
+    ├── mod.rs           # Main Editor logic
+    ├── mode.rs          # Normal/Insert modes
+    ├── command.rs       # Command definitions
+    ├── commandparser.rs # Vim-style command parsing
+    ├── commandbar.rs    # Command input UI
+    ├── messagebar.rs    # Status messages
+    ├── statusbar.rs     # File info display
+    ├── terminal.rs      # Terminal I/O
+    ├── view.rs          # Main editing buffer
+    ├── line.rs          # Line/text handling
+    └── ...
+```
+
+## Dependencies
+
+- [crossterm](https://crates.io/crates/crossterm) — Cross-platform terminal manipulation
+- [unicode-segmentation](https://crates.io/crates/unicode-segmentation) — Grapheme cluster handling
+- [unicode-width](https://crates.io/crates/unicode-width) — Character width calculation
+
+## Learning Goals
+
+This project is primarily a learning exercise. Through building it, I'm exploring:
+
+- Rust ownership and borrowing
+- Terminal raw mode and escape sequences
+- Building a TUI from scratch
+- Vim's modal editing philosophy
+- Unicode text handling complexities
+
+## License
+
+MIT
+
+---

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -347,9 +347,13 @@ impl Editor {
                     self.should_quit = true;
                 }
             }
-            ParsedCommand::Unknown(cmd) => {
-                self.message_bar
-                    .update_message(&format!("Unknown command: {}", cmd));
+             ParsedCommand::Unknown(cmd) => {
+                if cmd.is_empty() {
+                    self.message_bar.update_message("");
+                } else {
+                    self.message_bar
+                        .update_message(&format!("Unknown command: {}", cmd));
+                }
             }
             ParsedCommand::Help =>{
                 let help_message = "Commands: :w (write), :w <filename> (write as), :q (quit), :q! (force quit), :wq (write and quit), :wq <filename> (write as and quit), :help (this message)";

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -201,10 +201,21 @@ impl Editor {
                 } else if self.mode.is_normal() {
                     // In Normal mode, 'i' or 'I' enters Insert mode
                     if let command::Edit::Insert(ch) = edit_command {
-                        if ch == 'i' || ch == 'I' {
-                            self.mode = Mode::Insert;
-                            self.message_bar.update_message("-- INSERT --");
-                            self.refresh_status();
+                        match ch {
+                            '\u{1b}' => { /* Ignore ESC in normal mode */},
+                            'i' => {
+                                self.mode = Mode::Insert;
+                                self.message_bar.update_message("-- INSERT --");
+                                self.refresh_status();
+                            }
+                            'I' => {
+                                self.view.handle_move_command(command::Move::StartOfLine);
+                                self.mode = Mode::Insert;
+                                self.message_bar.update_message("-- INSERT --");
+                                self.refresh_status();
+                            },
+                        _ => {},
+                            
                         }
                     }
                 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -185,8 +185,6 @@ impl Editor {
             }
             System(ShowCommandBar) => {
                 self.show_prompt();
-                if self.command_bar.is_none() && self.mode.is_normal() {
-                }
             }
             Edit(edit_command) => {
                 if let Some(command_bar) = &mut self.command_bar {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -342,6 +342,10 @@ impl Editor {
                 self.message_bar
                     .update_message(&format!("Unknown command: {}", cmd));
             }
+            ParsedCommand::Help =>{
+                let help_message = "Commands: :w (write), :w <filename> (write as), :q (quit), :q! (force quit), :wq (write and quit), :wq <filename> (write as and quit), :help (this message)";
+                self.message_bar.update_message(help_message);
+            }
         }
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{read, Event, KeyEvent, KeyEventKind};
+use crossterm::event::{Event, KeyEvent, KeyEventKind, read};
 use std::{
     env,
     io::Error,
@@ -6,34 +6,35 @@ use std::{
 };
 mod command;
 mod commandbar;
+mod commandparser;
 mod documentstatus;
 mod line;
 mod messagebar;
+mod mode;
 mod position;
 mod size;
 mod statusbar;
 mod terminal;
 mod uicomponent;
 mod view;
-
-use documentstatus::DocumentStatus;
 use line::Line;
+use documentstatus::DocumentStatus;
+
+use self::command::{
+    Command::{self, Edit, Move, System},
+    Edit::InsertNewLine,
+    System::{Dismiss, Resize, ShowCommandBar},
+};
 use messagebar::MessageBar;
+use mode::Mode;
 use position::Position;
 use size::Size;
 use statusbar::StatusBar;
 use terminal::Terminal;
 use uicomponent::UIComponent;
 use view::View;
-use self::command::{
-    Command::{self, Edit, Move, System},
-    Edit::InsertNewLine,
-    System::{Dismiss, Quit, Resize, Save},
-};
 pub const NAME: &str = env!("CARGO_PKG_NAME");
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-const QUIT_TIMES: u8 = 3;
 
 #[derive(Default)]
 pub struct Editor {
@@ -45,6 +46,7 @@ pub struct Editor {
     terminal_size: Size,
     title: String,
     quit_times: u8,
+    mode: Mode,
 }
 
 impl Editor {
@@ -67,7 +69,6 @@ impl Editor {
                     .message_bar
                     .update_message(&format!("ERR: Could not open file: {file_name}"));
             }
-            
         }
         editor.refresh_status();
         editor.status_bar.set_requires_redraw(true);
@@ -101,8 +102,12 @@ impl Editor {
 
     pub fn refresh_status(&mut self) {
         let status = self.view.get_status();
+        let mode_str = match self.mode {
+            Mode::Normal => "NORMAL",
+            Mode::Insert => "INSERT",
+        };
 
-        let title = format!("{} - {NAME}", status.file_name);
+        let title = format!("{} - {NAME} [{}]", status.file_name, mode_str);
         self.status_bar.update_status(status);
 
         if title != self.title && matches!(Terminal::set_title(&title), Ok(())) {
@@ -137,8 +142,16 @@ impl Editor {
 
     #[allow(clippy::needless_pass_by_value)]
     fn evaluate_event(&mut self, event: Event) {
-         let should_process = match &event {
 
+        #[cfg(debug_assertions)]
+        if let Event::Key(key_event) = &event {
+            self.message_bar.update_message(&format!(
+                "Key: {:?}, Mods: {:?}, Kind: {:?}, State: {:?}",
+                key_event.code, key_event.modifiers, key_event.kind, key_event.state
+            ));
+        }
+
+        let should_process = match &event {
             Event::Key(KeyEvent { kind, .. }) => kind == &KeyEventKind::Press,
             Event::Resize(_, _) => true,
             _ => false,
@@ -150,51 +163,61 @@ impl Editor {
             }
         }
     }
-    
+
     fn process_command(&mut self, command: Command) {
         match command {
-            System(Quit) => {
-                if self.command_bar.is_none() {
-                    self.handle_quit();
-                }
-            }
             System(Resize(size)) => self.resize(size),
             _ => self.reset_quit_times(),
         }
+
         match command {
-            System(Quit | Resize(_)) => {},
-            System(Save) => {
-                if self.command_bar.is_none(){
-                    self.handle_save();
+            System( Resize(_)) => {}
+            System(Dismiss) => {
+                if self.command_bar.is_some() {
+                    self.dismiss_prompt();
+                    self.message_bar.update_message("Command cancelled.");
+                } else if self.mode.is_insert() {
+                    // ESC exits insert mode
+                    self.mode = Mode::Normal;
+                    self.message_bar.update_message("");
+                    self.refresh_status();
                 }
             }
-            System(Dismiss) => {
-                if self.command_bar.is_some(){
-                    self.dismiss_prompt();
-                    self.message_bar.update_message("Save aborted.");
+            System(ShowCommandBar) => {
+                self.show_prompt();
+                if self.command_bar.is_none() && self.mode.is_normal() {
                 }
             }
             Edit(edit_command) => {
                 if let Some(command_bar) = &mut self.command_bar {
                     if matches!(edit_command, InsertNewLine) {
-                        let file_name = command_bar.value();
+                        let command_input = command_bar.value();
                         self.dismiss_prompt();
-                        self.save(Some(&file_name));
+                        self.execute_command(&command_input);
                     } else {
                         command_bar.handle_edit_command(edit_command);
                     }
-                } else {
+                } else if self.mode.is_insert() {
+                    // Only allow editing in Insert mode
                     self.view.handle_edit_command(edit_command);
+                } else if self.mode.is_normal() {
+                    // In Normal mode, 'i' or 'I' enters Insert mode
+                    if let command::Edit::Insert(ch) = edit_command {
+                        if ch == 'i' || ch == 'I' {
+                            self.mode = Mode::Insert;
+                            self.message_bar.update_message("-- INSERT --");
+                            self.refresh_status();
+                        }
+                    }
                 }
             }
             Move(move_command) => {
                 if self.command_bar.is_none() {
                     self.view.handle_move_command(move_command);
                 }
-            },
+            }
         }
     }
-
     fn dismiss_prompt(&mut self) {
         self.command_bar = None;
         self.message_bar.set_requires_redraw(true);
@@ -202,7 +225,7 @@ impl Editor {
 
     fn show_prompt(&mut self) {
         let mut command_bar = commandbar::CommandBar::default();
-        command_bar.set_prompt("Save as: ");
+        command_bar.set_prompt(":");
         command_bar.resize(Size {
             height: 1,
             width: self.terminal_size.width,
@@ -211,38 +234,23 @@ impl Editor {
         self.command_bar = Some(command_bar);
     }
 
-    fn handle_save(&mut self) {
-        if self.view.is_file_loaded() {
-            self.save(None)
-        } else {
-            self.show_prompt();
-        }
-    }
-
-    fn save(&mut self, file_name: Option<&str>) {
+    fn save(&mut self, file_name: Option<&str>) -> Result<(), std::io::Error> {
         let result = if let Some(name) = file_name {
             self.view.save_as(name)
         } else {
             self.view.save()
         };
-        if result.is_ok() {
-            self.message_bar.update_message("File saved successfully.");
-        } else {
-            self.message_bar.update_message("Error writing file!");
-        }
-    }
 
-    fn handle_quit(&mut self){
-        if !self.view.get_status().is_modified || self.quit_times + 1 == QUIT_TIMES {
-            self.should_quit = true;
-        } else if self.view.get_status().is_modified {
-            self.message_bar.update_message(&format!(
-                "WARNING: File has unsaved changes. Press Ctrl-Q {} more times to quit.",
-                QUIT_TIMES - self.quit_times - 1
-            ));
-
-            self.quit_times += 1;
+        match &result {
+            Ok(_) => {
+                self.message_bar.update_message("File saved successfully.");
+                self.refresh_status(); // Refresh to update modified status
+            }
+            Err(_) => {
+                self.message_bar.update_message("Error writing file!");
+            }
         }
+        result
     }
 
     fn reset_quit_times(&mut self) {
@@ -258,7 +266,7 @@ impl Editor {
         }
         let bottom_bar_row = self.terminal_size.height.saturating_sub(1);
         let _ = Terminal::hide_caret();
-        
+
         if let Some(command_bar) = &mut self.command_bar {
             command_bar.render(bottom_bar_row);
         } else {
@@ -273,7 +281,7 @@ impl Editor {
         if self.terminal_size.height > 2 {
             self.view.render(0);
         }
-        
+
         let new_carret_position = if let Some(command_bar) = &self.command_bar {
             Position {
                 row: bottom_bar_row,
@@ -285,6 +293,56 @@ impl Editor {
         let _ = Terminal::move_caret_to(new_carret_position);
         let _ = Terminal::show_caret();
         let _ = Terminal::execute();
+    }
+
+    fn execute_command(&mut self, input: &str) {
+        use commandparser::ParsedCommand;
+
+        let command = ParsedCommand::parse(input);
+
+        match command {
+            ParsedCommand::Write => {
+                if self.view.is_file_loaded() {
+                    let _ = self.save(None);
+                } else {
+                    self.message_bar
+                        .update_message("No file name. Use :w <filename>");
+                }
+            }
+            ParsedCommand::WriteAs(filename) => {
+                let _ = self.save(Some(&filename));
+            }
+            ParsedCommand::Quit => {
+                if self.view.get_status().is_modified {
+                    self.message_bar
+                        .update_message("No write since last change. Use :q! to force quit.");
+                } else {
+                    self.should_quit = true;
+                }
+            }
+            ParsedCommand::ForceQuit => {
+                self.should_quit = true;
+            }
+            ParsedCommand::WriteQuit => {
+                if self.view.is_file_loaded() {
+                    if self.save(None).is_ok() {
+                        self.should_quit = true;
+                    }
+                } else {
+                    self.message_bar
+                        .update_message("No file name. Use :wq <filename>");
+                }
+            }
+            ParsedCommand::WriteAsAndQuit(filename) => {
+                if self.save(Some(&filename)).is_ok() {
+                    self.should_quit = true;
+                }
+            }
+            ParsedCommand::Unknown(cmd) => {
+                self.message_bar
+                    .update_message(&format!("Unknown command: {}", cmd));
+            }
+        }
     }
 }
 

--- a/src/editor/command.rs
+++ b/src/editor/command.rs
@@ -1,13 +1,13 @@
 use crossterm::event::{
     Event,
     KeyCode::{
-        self, Backspace, Char, Delete, Down, End, Enter, Home, Left, PageDown, PageUp, Right, Tab, Up,
+        self, Backspace, Char, Delete, Down, End, Enter, Home, Left, PageDown, PageUp, Right, Tab,
+        Up,
     },
     KeyEvent, KeyModifiers,
 };
 
 use std::convert::TryFrom;
-
 use super::Size;
 
 #[derive(Clone, Copy)]
@@ -28,7 +28,7 @@ impl TryFrom<KeyEvent> for Move {
         let KeyEvent {
             code, modifiers, ..
         } = event;
-        
+
         if modifiers == KeyModifiers::NONE {
             match code {
                 Up => Ok(Self::Up),
@@ -54,12 +54,12 @@ pub enum Edit {
     Insert(char),
     InsertNewLine,
     Delete,
-    DeleteBackward
+    DeleteBackward,
 }
 
 impl TryFrom<KeyEvent> for Edit {
     type Error = String;
-     fn try_from(event: KeyEvent) -> Result<Self, Self::Error> {
+    fn try_from(event: KeyEvent) -> Result<Self, Self::Error> {
         match (event.code, event.modifiers) {
             (Char(character), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
                 Ok(Self::Insert(character))
@@ -78,32 +78,32 @@ impl TryFrom<KeyEvent> for Edit {
 
 #[derive(Clone, Copy)]
 pub enum System {
-    Save,
     Resize(Size),
-    Quit,
-    Dismiss
+    Dismiss,
+    ShowCommandBar,
 }
 
 impl TryFrom<KeyEvent> for System {
     type Error = String;
-    
+
     fn try_from(event: KeyEvent) -> Result<Self, Self::Error> {
         let KeyEvent {
             code, modifiers, ..
         } = event;
         
-        if modifiers == KeyModifiers::CONTROL {
+        if modifiers == KeyModifiers::NONE {
             match code {
-                Char('q') => Ok(Self::Quit),
-                Char('s') => Ok(Self::Save),
+                KeyCode::Esc => Ok(Self::Dismiss),
+                Char(':') => Ok(Self::ShowCommandBar),
+                _ => Err(format!("Unrecognized key: {code:?}")),
+            }
+        } else if modifiers == KeyModifiers::CONTROL {
+            match code {
                 _ => Err(format!("Unrecognized CONTROL+{code:?} combination")),
             }
-        } else if modifiers == KeyModifiers::NONE && matches!(code, KeyCode::Esc){
-            Ok(Self::Dismiss)
-        }
-         else {
+        } else {
             Err(format!(
-                 "Unsupported key code {code:?} or modifier {modifiers:?}",
+                "Unsupported key code {code:?} or modifier {modifiers:?}",
             ))
         }
     }
@@ -121,18 +121,17 @@ impl TryFrom<Event> for Command {
     type Error = String;
 
     fn try_from(event: Event) -> Result<Self, Self::Error> {
-        match event{
-            Event::Key(key_event) => Edit::try_from(key_event)
-            .map(Command::Edit)
-            .or_else(|_| Move::try_from(key_event).map(Command::Move))
-            .or_else(|_| System::try_from(key_event).map(Command::System))
-            .map_err(|_err| format!("Event not supported: {key_event:?}")),
-            Event::Resize(width_u16, height_u16 ) => Ok(Self::System(System::Resize(Size {
+        match event {
+            Event::Key(key_event) => System::try_from(key_event)  // Check System FIRST
+                .map(Command::System)
+                .or_else(|_| Move::try_from(key_event).map(Command::Move))
+                .or_else(|_| Edit::try_from(key_event).map(Command::Edit))  // Edit LAST
+                .map_err(|_err| format!("Event not supported: {key_event:?}")),
+            Event::Resize(width_u16, height_u16) => Ok(Self::System(System::Resize(Size {
                 height: height_u16 as usize,
                 width: width_u16 as usize,
             }))),
             _ => Err(format!("Event not supported: {event:?}")),
-
         }
     }
 }

--- a/src/editor/command.rs
+++ b/src/editor/command.rs
@@ -87,24 +87,13 @@ impl TryFrom<KeyEvent> for System {
     type Error = String;
 
     fn try_from(event: KeyEvent) -> Result<Self, Self::Error> {
-        let KeyEvent {
-            code, modifiers, ..
-        } = event;
-        
-        if modifiers == KeyModifiers::NONE {
-            match code {
-                KeyCode::Esc => Ok(Self::Dismiss),
-                Char(':') => Ok(Self::ShowCommandBar),
-                _ => Err(format!("Unrecognized key: {code:?}")),
-            }
-        } else if modifiers == KeyModifiers::CONTROL {
-            match code {
-                _ => Err(format!("Unrecognized CONTROL+{code:?} combination")),
-            }
-        } else {
-            Err(format!(
-                "Unsupported key code {code:?} or modifier {modifiers:?}",
-            ))
+        match (event.code, event.modifiers) {
+            (KeyCode::Esc, KeyModifiers::NONE) => Ok(Self::Dismiss),
+            (Char(':'), KeyModifiers::NONE | KeyModifiers::SHIFT) => Ok(Self::ShowCommandBar),
+            _ => Err(format!(
+                "Unsupported key code {:?} or modifier {:?}",
+                event.code, event.modifiers
+            )),
         }
     }
 }

--- a/src/editor/commandparser.rs
+++ b/src/editor/commandparser.rs
@@ -7,6 +7,7 @@ pub enum ParsedCommand {
     WriteAsAndQuit(String), // :wq filename
     WriteAs(String),    // :w filename
     Unknown(String),
+    Help,             // :help
 }
 
 impl ParsedCommand {
@@ -31,6 +32,7 @@ impl ParsedCommand {
                 }
             }
             "q" | "quit" => Self::Quit,
+            "h" | "help" => Self::Help,
             "q!" | "quit!" => Self::ForceQuit,
             "wq" | "x" => {
                 if args.is_empty() {

--- a/src/editor/commandparser.rs
+++ b/src/editor/commandparser.rs
@@ -1,0 +1,69 @@
+#[derive(Debug, PartialEq)]
+pub enum ParsedCommand {
+    Write,              // :w
+    Quit,               // :q
+    WriteQuit,          // :wq or :x
+    ForceQuit,          // :q!
+    WriteAsAndQuit(String), // :wq filename
+    WriteAs(String),    // :w filename
+    Unknown(String),
+}
+
+impl ParsedCommand {
+    pub fn parse(input: &str) -> Self {
+        let trimmed = input.trim();
+        
+        if trimmed.is_empty() {
+            return Self::Unknown(String::new());
+        }
+        
+        // Split the command and arguments
+        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+        let command = parts[0];
+        let args = &parts[1..];
+        
+        match command {
+            "w" | "write" => {
+                if args.is_empty() {
+                    Self::Write
+                } else {
+                    Self::WriteAs(args.join(" "))
+                }
+            }
+            "q" | "quit" => Self::Quit,
+            "q!" | "quit!" => Self::ForceQuit,
+            "wq" | "x" => {
+                if args.is_empty() {
+                    Self::WriteQuit
+                } else {
+                    Self::WriteAsAndQuit(args.join(" "))
+                }
+            }
+            _ => Self::Unknown(trimmed.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_commands() {
+        assert_eq!(ParsedCommand::parse("w"), ParsedCommand::Write);
+        assert_eq!(ParsedCommand::parse("write"), ParsedCommand::Write);
+        assert_eq!(ParsedCommand::parse("q"), ParsedCommand::Quit);
+        assert_eq!(ParsedCommand::parse("quit"), ParsedCommand::Quit);
+        assert_eq!(ParsedCommand::parse("q!"), ParsedCommand::ForceQuit);
+        assert_eq!(ParsedCommand::parse("wq"), ParsedCommand::WriteQuit);
+        assert_eq!(ParsedCommand::parse("x"), ParsedCommand::WriteQuit);
+        assert_eq!(
+            ParsedCommand::parse("w test.txt"),
+            ParsedCommand::WriteAs("test.txt".to_string())
+        );
+        assert_eq!(
+            ParsedCommand::parse("wq test.txt"),
+            ParsedCommand::WriteAsAndQuit("test.txt".to_string())
+        );
+    }
+}

--- a/src/editor/mode.rs
+++ b/src/editor/mode.rs
@@ -1,0 +1,16 @@
+#[derive(Default, PartialEq, Clone, Copy)]
+pub enum Mode {
+    #[default]
+    Normal,
+    Insert,
+}
+
+impl Mode {
+    pub fn is_normal(&self) -> bool {
+        matches!(self, Mode::Normal)
+    }
+
+    pub fn is_insert(&self) -> bool {
+        matches!(self, Mode::Insert)
+    }
+}

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -1,8 +1,10 @@
 use std::{cmp::min, io::Error};
 
+use crate::editor::documentstatus::DocumentStatus;
+
 use super::{
+    Line, NAME, Position, Size, Terminal, UIComponent, VERSION,
     command::{Edit, Move},
-    DocumentStatus, Line, Position, Size, Terminal, UIComponent, NAME, VERSION,
 };
 
 mod buffer;
@@ -25,7 +27,6 @@ pub struct View {
 }
 
 impl View {
-
     pub const fn is_file_loaded(&self) -> bool {
         self.buffer.is_file_loaded()
     }
@@ -41,7 +42,7 @@ impl View {
         }
     }
 
-    pub fn handle_move_command(&mut self, command: Move){
+    pub fn handle_move_command(&mut self, command: Move) {
         let Size { height, .. } = self.size;
         match command {
             Move::Up => self.move_up(1),
@@ -89,7 +90,7 @@ impl View {
             .map_or(0, Line::grapheme_count);
 
         self.buffer.insert_char(character, self.text_location);
-        
+
         let new_len = self
             .buffer
             .lines
@@ -237,8 +238,6 @@ impl View {
         self.text_location.line_index = min(self.text_location.line_index, self.buffer.height());
     }
 
-    
-
     pub fn get_status(&self) -> DocumentStatus {
         DocumentStatus {
             total_lines: self.buffer.height(),
@@ -257,13 +256,12 @@ impl UIComponent for View {
     fn requires_redraw(&self) -> bool {
         self.requires_redraw
     }
-    
 
     fn set_size(&mut self, size: Size) {
         self.size = size;
         self.scroll_text_location_into_view();
     }
-    
+
     fn draw(&mut self, origin_y: usize) -> Result<(), Error> {
         let Size { height, width } = self.size;
         let end_y = origin_y.saturating_add(height);
@@ -272,11 +270,11 @@ impl UIComponent for View {
         #[allow(clippy::integer_division)]
         let top_third = height / 3;
         let scroll_top = self.scroll_offset.row;
-        for current_row in origin_y..end_y {  
-           // to get the correct line index, we have to take current_row (the absolute row on screen),
+        for current_row in origin_y..end_y {
+            // to get the correct line index, we have to take current_row (the absolute row on screen),
             // subtract origin_y to get the current row relative to the view (ranging from 0 to self.size.height)
             // and add the scroll offset.
-            let line_idx = current_row  
+            let line_idx = current_row
                 .saturating_sub(origin_y)
                 .saturating_add(scroll_top);
             if let Some(line) = self.buffer.lines.get(line_idx) {
@@ -290,6 +288,5 @@ impl UIComponent for View {
             }
         }
         Ok(())
-          }
-    
+    }
 }

--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -1,10 +1,8 @@
 use std::io::{Write, Error};
 use std::fs::{read_to_string, File};
-
 use super::{Line, Location, FileInfo};
 pub struct Buffer {
     pub lines: Vec<Line>,
-    pub file_name: Option<String>,
     pub dirty: bool,
     pub file_info: FileInfo
 }
@@ -13,7 +11,6 @@ impl Default for Buffer {
     fn default() -> Self {
         Self {
             lines: vec![Line::default()], // Start with at least one empty line
-            file_name: None,
             dirty: false,
             file_info: FileInfo::default(),
         }
@@ -30,7 +27,6 @@ impl Buffer {
 
         let buffer = Self {
             lines,
-            file_name: Some(file_name.to_string()),
             dirty: false,
             file_info: FileInfo::from(file_name),
         };


### PR DESCRIPTION
This pull request introduces a significant refactor of the editor to support modal editing (Normal and Insert modes), adds a Vim-like command bar with support for commands such as `:w`, `:q`, and `:wq`, and improves the internal command parsing and execution. The changes include the addition of a mode system, a new command parser, and a reorganization of how commands and key events are handled. This lays the groundwork for extensible modal editing and a more powerful command interface.

Key changes:

### Modal Editing Support

* Added a new `Mode` enum (`Normal`, `Insert`) in `mode.rs`, and integrated it into the `Editor` struct and editing flow. The editor now defaults to Normal mode and only allows text editing in Insert mode, similar to Vim. Pressing `i` or `I` enters Insert mode, and `Esc` returns to Normal mode. The current mode is displayed in the window title and status bar. [[1]](diffhunk://#diff-4eec0bc411e831ff62d4e99921085855358544e304a38170eff164748067d2e7R1-R16) [[2]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bR49) [[3]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bR105-R110) [[4]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bL156-R228)

### Command Bar and Command Parsing

* Introduced a new `commandparser.rs` module with a `ParsedCommand` enum and parser for Vim-like commands (`:w`, `:q`, `:wq`, etc.), including support for file names and error handling.
* The command bar now uses `:` as its prompt and passes input to the new command parser. The editor executes parsed commands accordingly, handling writes, quits, and error messages. [[1]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bL156-R228) [[2]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bR297-R346)

### Key Event and Command Handling Refactor

* Refactored `command.rs` so that system commands (such as `Dismiss` and `ShowCommandBar`) are detected before edit and move commands, allowing for more intuitive modal and command bar interactions. [[1]](diffhunk://#diff-d9f8fdeee5e3463e656a9300d7bd689061c16bdf015646ab6fa8aa9c2eb7b15cL81-R83) [[2]](diffhunk://#diff-d9f8fdeee5e3463e656a9300d7bd689061c16bdf015646ab6fa8aa9c2eb7b15cL95-R104) [[3]](diffhunk://#diff-d9f8fdeee5e3463e656a9300d7bd689061c16bdf015646ab6fa8aa9c2eb7b15cL125-L135)
* Updated key event handling to distinguish between Normal and Insert modes, and to trigger the command bar with `:` and dismiss it with `Esc`. [[1]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bL140-R154) [[2]](diffhunk://#diff-d9f8fdeee5e3463e656a9300d7bd689061c16bdf015646ab6fa8aa9c2eb7b15cL95-R104)

### Save and Quit Logic Improvements

* Replaced the previous multi-step quit confirmation with modal and command-based logic: quitting now checks for unsaved changes and provides appropriate messages, and forced quit is handled via `:q!`. Save logic is streamlined and now returns a `Result`, with messages updated accordingly. [[1]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bL214-R253) [[2]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bR297-R346)

### Code Cleanup and Organization

* Removed unused or redundant code (such as the old quit logic and unused fields), improved module imports, and cleaned up formatting and structure for clarity. [[1]](diffhunk://#diff-d3e337699fa6947e80e3b9cec50fc80e7550368a7b46ae6107e734909063cf9bL1-L37) [[2]](diffhunk://#diff-1736b60b70e9ac99fa7ab327c7f08fa6f34f5d7ac0487343d8dfa34e3d5819c1L3-L7) [[3]](diffhunk://#diff-1736b60b70e9ac99fa7ab327c7f08fa6f34f5d7ac0487343d8dfa34e3d5819c1L16) [[4]](diffhunk://#diff-1736b60b70e9ac99fa7ab327c7f08fa6f34f5d7ac0487343d8dfa34e3d5819c1L33)

These changes collectively make the editor more extensible, robust, and familiar to users of modal editors like Vim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal editing (Normal/Insert) with mode shown in status
  * Command bar (":" prompt) with parsed editor commands (write, quit, force, help, filename variants)

* **Bug Fixes / UX**
  * ESC toggles Insert↔Normal reliably; status and messages refresh after commands and saves
  * Improved delete/backspace behavior and command flow (show/dismiss command prompt)

* **Documentation**
  * New comprehensive README with usage, keybindings, installation and roadmap

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->